### PR TITLE
chore: add WartRemover plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,13 @@ lazy val circeVersion = "0.13.0"
 lazy val finchVersion = "0.32.1"
 lazy val pureconfigVersion = "0.14.0"
 
+val disabledWarts = Set(
+  Wart.Any, // cats
+  Wart.NonUnitStatements // test assertions
+)
+
+wartremoverWarnings ++= Warts.unsafe.filterNot(disabledWarts.contains)
+
 scalacOptions ++= Seq(
   "-encoding",
   "UTF-8", // source files are in UTF-8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.16")

--- a/src/main/scala/io/gatling/interview/App.scala
+++ b/src/main/scala/io/gatling/interview/App.scala
@@ -28,7 +28,7 @@ final class App[F[_]: ConcurrentEffect: ContextShift: Timer] {
         _ <- setup(config).use { server =>
           for {
             _ <- logger.info(
-              s"Server started and bound to: ${server.boundAddress}"
+              s"Server started and bound to: ${server.boundAddress.toString}"
             )
             _ <- ConcurrentEffect[F].never.as(())
           } yield ()
@@ -59,7 +59,7 @@ final class App[F[_]: ConcurrentEffect: ContextShift: Timer] {
         Http.server
           .withStreaming(enabled = true)
           .withExecutionOffloaded(serverExecutorService)
-          .serve(s":${config.port}", service)
+          .serve(s":${config.port.toString}", service)
       }
     )(s => Sync[F].suspend(implicitly[ToAsync[Future, F]].apply(s.close())))
 


### PR DESCRIPTION
Motivation:
Candidates are not used to functional paradigms and make common mistake easily spotted.

Modifications:
Add and configure WartRemover plugin

Result:
Less common pitfalls



Notes for reviewers:
 * As `"-Xfatal-warnings"` is defined in our `scalacOptions`, the wartremover warnings are considered as errors